### PR TITLE
Adds a JDK image and renames accordingly

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,4 +1,4 @@
-# zipkin-docker-jre rationale
+# docker-java rationale
 
 ## Why do we use Alpine Linux instead of Distroless?
 
@@ -18,12 +18,12 @@ Alpine does this by default.
 We are often criticized for the size of our Docker image, as it is an ancillary
 part of people's environments. Zipkin's 'slim' build is currently a 26MB jar
 file. The bulk of the size left is the JRE. Here's a comparison of size between
-a comparible build of the same JRE, one with Distroless (Debian based) and the
+a comparable build of the same JRE, one with Distroless (Debian based) and the
 other Alpine.
 
 ```
-openzipkin/jre-full                  alpine              128317d6038e        20 seconds ago      87.1MB
-openzipkin/jre-full                  distroless          0717ad881158        3 minutes ago       102MB
+openzipkin/java                  alpine              128317d6038e        20 seconds ago      87.1MB
+openzipkin/java                  distroless          0717ad881158        3 minutes ago       102MB
 ```
 
 ### We are still smaller adding BoringSSL support

--- a/README.md
+++ b/README.md
@@ -1,20 +1,29 @@
-`openzipkin/jre-full` is a minimal JRE Docker image based on [azul/zulu-openjdk-alpine](https://hub.docker.com/r/azul/zulu-openjdk-alpine).
+`openzipkin/java` is a minimal Docker image based on [azul/zulu-openjdk-alpine](https://hub.docker.com/r/azul/zulu-openjdk-alpine).
 
-On Dockerhub: [openzipkin/jre-full](https://hub.docker.com/r/openzipkin/jre-full/)
+On Dockerhub: [openzipkin/java](https://hub.docker.com/r/openzipkin/java/) there will be two tags
+per version. The one ending in `-jre` is a minimal build including modules Zipkin related images
+need. The unqualified is a JDK that also includes Maven.
 
 ## Release process
+The Docker build is driven by `--build-arg zulu_tag`. The value of this must be Zulu's most-specific
+Java 15 tag, ex `15.0.0-15.27.17`.
+ * You can look here https://hub.docker.com/r/azul/zulu-openjdk-alpine/tags?page=1&name=15
 
-New versions are built on [Travis CI](https://travis-ci.org/openzipkin/docker-jre-full). To trigger a build, push a new tag to GitHub. The tag will be the Docker tag assigned to the newly built image. Name the tag according to the JDK variant use.
+Build the `Dockerfile` and verify the image you built matches that tag.
+Ex. `docker build -t openzipkin/java:test-jre --build-arg zulu_tag=15.0.0-15.27.17 .`
 
-For example, with the following output from `docker run --rm (image built) -version`:
+Next, verify the built image matches that `zulu_tag`.
+
+For example, given the following output from `docker run --rm openzipkin/java:test-jre -version`...
 ```
 openjdk version "15" 2020-09-15
 OpenJDK Runtime Environment Zulu15.27+17-CA (build 15+36)
 OpenJDK 64-Bit Server VM Zulu15.27+17-CA (build 15+36, mixed mode)
 ```
+The `zulu_tag` arg should be `15.0.0-15.27.17`
 
-You would name the tag `15.0.0-15.27.17`, which makes sense as it corresponds to...
- * Zulu's most-specific tag the JRE image https://hub.docker.com/r/azul/zulu-openjdk-alpine/tags?page=1&name=15
+To release the image, push a tag named the same as the `zulu_tag` you built (ex `15.0.0-15.27.17`).
+This will trigger a [Travis CI](https://travis-ci.org/openzipkin/docker-java) job to push the image.
 
 Note: The upstream Zulu repository has a monthly release cadence. Maintainers should [watch the repo](https://github.com/zulu-openjdk/zulu-openjdk/watchers),
 in case a pull request corresponds to a release. Since not all releases correspond to pull requests,

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Copyright 2015-2020 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -eux
+
+# By default $JAVA_HOME/bin isn't in the path, even if java is.
+# We only use jar, so special case it.
+ln -s $JAVA_HOME/bin/jar /usr/local/bin/jar
+
+echo "*** Installing Maven and dependencies"
+# BusyBux built-in tar doesn't support --strip=1
+# Allow boringssl for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
+apk add --update --no-cache tar libc6-compat
+
+# Java relies on /etc/nsswitch.conf. Put host files first or InetAddress.getLocalHost
+# will throw UnknownHostException as the local hostname isn't in DNS.
+echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+
+# Use latest stable version here
+MAVEN_VERSION=3.6.3
+mkdir /usr/local/maven && cd /usr/local/maven
+APACHE_MIRROR=$(wget -qO- https://www.apache.org/dyn/closer.cgi\?as_json\=1 | sed -n '/preferred/s/.*"\(.*\)"/\1/gp')
+wget -qO- $APACHE_MIRROR/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xz --strip=1
+ln -s /usr/local/maven/bin/mvn /usr/local/bin/mvn

--- a/install.sh
+++ b/install.sh
@@ -15,18 +15,9 @@
 
 set -eux
 
-# By default $JAVA_HOME/bin isn't in the path, even if java is.
-# We only use jar, so special case it.
-ln -s $JAVA_HOME/bin/jar /usr/local/bin/jar
-
 echo "*** Installing Maven and dependencies"
 # BusyBux built-in tar doesn't support --strip=1
-# Allow boringssl for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
-apk add --update --no-cache tar libc6-compat
-
-# Java relies on /etc/nsswitch.conf. Put host files first or InetAddress.getLocalHost
-# will throw UnknownHostException as the local hostname isn't in DNS.
-echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+apk add --update --no-cache tar
 
 # Use latest stable version here
 MAVEN_VERSION=3.6.3

--- a/release.sh
+++ b/release.sh
@@ -7,14 +7,15 @@
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 version"
-    echo "  version: the version output from building azul/zulu-openjdk-debian "
+    echo "Usage: $0 zulu_tag"
+    echo "  version: the version output from building zulu-openjdk-alpine "
     exit 1
 fi
-version="$1"
-tag="openzipkin/jre-full:$version"
+
+ZULU_TAG="$1"
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
-docker build --squash -t "$tag" .
+docker build --build-arg zulu_tag=${ZULU_TAG} --squash -t "openzipkin/java:${ZULU_TAG}" --target jdk .
+docker build --build-arg zulu_tag=${ZULU_TAG} --squash -t "openzipkin/java:${ZULU_TAG}-jre" --target jre .
 
 docker push "$tag"

--- a/release.sh
+++ b/release.sh
@@ -14,8 +14,7 @@ fi
 
 ZULU_TAG="$1"
 
-export DOCKER_CLI_EXPERIMENTAL=enabled
-docker build --build-arg zulu_tag=${ZULU_TAG} --squash -t "openzipkin/java:${ZULU_TAG}" --target jdk .
-docker build --build-arg zulu_tag=${ZULU_TAG} --squash -t "openzipkin/java:${ZULU_TAG}-jre" --target jre .
+docker build --build-arg zulu_tag=${ZULU_TAG} -t "openzipkin/java:${ZULU_TAG}" --target jdk .
+docker build --build-arg zulu_tag=${ZULU_TAG} -t "openzipkin/java:${ZULU_TAG}-jre" --target jre .
 
 docker push "$tag"


### PR DESCRIPTION
This renames our Docker image following somewhat how zulu does things
 * openzipkin/java:15.0.0-15.27.17 would be a JDK
 * openzipkin/java:15.0.0-15.27.17-jre would be a JRE

Fixes #27