### PR TITLE
Removes JMX from the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,16 +64,12 @@ java.desktop,\
 java.sql,\
 # instrumentation
 java.instrument,\
-# we don't use JMX, but log4j2 errors without it: LOG4J2-716
-java.management,\
 # remote debug
 jdk.jdwp.agent,\
 # JVM metrics such as garbage collection
 jdk.management,\
-# prevents us from needing a different base layer for kafka-zookeeper
-# ZooKeeper needs jdk.management.agent, and adding it is 900K vs 200M for a different base layer
-jdk.management.agent,\
-# non-netty based DNS
+# Prevents us from needing a different base layer for kafka-zookeeper
+# non-Netty based DNS
 java.naming,jdk.naming.dns,\
 # TLS handehake with servers that use elliptic curve certificates
 jdk.crypto.ec,\


### PR DESCRIPTION
This removes JMX to save size in our base layer. Typical use requires
disabling some options such as:

* -Dlog4j2.disable.jmx=true
* -Dzookeeper.jmx.log4j.disable=true

See https://github.com/openzipkin/zipkin/pull/3252