### PR TITLE
Switches to ghcr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 
 before_script:
   # Log in to Docker Hub for releasing the image
-  - docker login -u dockerzipkindeployer -p "$DOCKERHUB_PASSWORD"
+  - echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
 
 script: ./release.sh $TRAVIS_TAG
 
@@ -23,11 +23,13 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/ead3c37d57527214e9f2
-      - https://webhooks.gitter.im/e/e57478303f87ecd7bffc
+      - https://webhooks.gitter.im/e/9f1ee2f315d32956f8d6
     on_success: change
     on_failure: always
 
 env:
   global:
-    # Docker Hub credentials
-    secure: O+P9Rkwsd866JucLwPt6Db8jTm4PN6SdKtP0X46Hgl2s5HZh4ude8TXkVe+hlGu7eXV2AoVG8b7FDaptzY8thtWMao2HNBcTgbUh4yhvdsN2y9+JUNVwxxgarCBoyqwKDbS0JtWfO22ms4Au+hGA1cfG5t/Qpr0eGaNxoNvsTs72CfeyDCZhzSeTbZeQDdAUqX9CCgrB6TB/3ZA3wCS7qptna0HW/+aZRSMGHQzM9oGYlSaWa7HHGMa2llsGK5lRMpPL/GNdFlZRTgqtjIvMAfZHqXPgdIOZ9clO/nntcIx1VAtExqalneXchj4GciJ3EvniPc5QX91m4S7/R3KTkk8IDjK3SpxfMo4KrOkbL93bl9Ku82LNPCmxvSPn3moznQI7AX1kIzxPapqVElEJL3pDVPre561gCb4IQjR9L7ZvS3gUd36VoFg1VHjqwPjM6Re36o4s3NXmQzITu6SkJ0OZQpOdLAiVi/2nvcSaU8jl4boCnoramqoRYkeMkt91k8gNA+CEzXS9/WKQy1PI9ZeS2mmct6yYePwUG+ZETv/FodEUFY9OdSL7LwDc5BxMKwG10+3N3glJcKljag3vZtjCZ5O11TRCRcwEkcdcPHgwaH4M5EQVeF023YsG8VkEcufEuHvrjIuMTAC354Q/LyQjr/1UufsodyX3eh8kcx0=
+    # Ex. travis encrypt GH_USER=your_github_account
+    - secure: "BWJH4sEQMREo0pEiKc911uNDEFUS9/8S6qXbfouECLGkganh/8XfNR2tOTAna/paUzE/HIq5kb8ayDPj0hWrZ8onAPB5eN8n5/xF/c8iIjYyNEudmKmJdpm0gNkvnxVBVoaNUQPR/sRYMf5vLhwff24buwNARkTn2jxJdVJJktQU12432UjaWR0y1vekgUfiZOlbVwxPvtImPIu0jQipPikG6RgcvFwd5kqK3LVIw1Kox9/44EpwFZIeiwW/f/jxV6bTbnwlps6k44JgOVbygZRwqwmh+OpB8dbdw++agUkd3NcuEDyv4LE9UG9UknYAuAxt++Jns2QjXMt2oMG3+aZiJjbmLB7imP7GDfrDNzDiOYxUIwFsAXC6VXD3NaPt974KxEL3aZLlQAPztC9Wg60fC3SBWoXpYbYsw22qd72bK4Bk8Lms1y4AvZcRwguCnati1FpO0voKS+NnexwDQjJFgRy0NAeRiAHSmO05NB4aqKUIFKLyupqUNt2zECHqVElbZ7tCPv++kxNEgYzPDekcCglk9DFOnbbyRLTm3puI8dpJNhnVEhfkbMnXmU7nhusX1zCSqHaWz8l4spRPtgDgBcYDrVnfwMc3STL3IQe1CAqbf11+28AtfExeR/jEncfIEWTqW2wya/Q1eLl267vq6Ao1c0K9CQRyvp0URf0="
+    # Ex. travis encrypt GH_TOKEN=XXX-https://github.com/settings/tokens-XXX --add
+    - secure: "Zq/LtJSN5O5wxw5mSoadJTWXi4nNaw2irmydq6l/IWCFeOHBlibW7KFFd1ImiY/4v5WDboynKHagOd0zayo7V8woI2d74t0rksaOh7QqZJ4gAxi2oCWLeSHFvZWRZYu2RxopqIpN0UPrJSThSO+R3zZpvK9Dz1VWoOniXvxa7iYfHtgzXObqCGCMEhvRKZNfM+2eG3OXlIG7mnj6hRIjD/lfJiCOZBvekl+zTyg5p/Z1wQCFLFGC5NAYYPgZll+Jgt7LLzlUhx1AOcWAsonxcLL40v+FvslZMVRvDCRZBxedI/jaBDtIJwTsE87B5h0F7M3Teo0oqiImn6mWejMcDPVhwY1m/VwBaAmpip7nx+9EXDZtNn5jb4QiIkT7MxUxpLHbop3WhIa8rn0ybNAlKY2LF2v9Z932H92fbEvOfVhZuDACZ9DGIVXkv/XRIXiNvvYNEZyJ0Tc4U7NG1LFw/BxTPY1HnmOf1uuA2Alboj5A9LOvXHkP3ej2Tqx1lQdDTdqHCeeADwcidekLYhi0caiNn1mE9o44CkSnAJKZMrkL4gWTAMjYyC2j30puI8nhxqlYITwoyZWDxA+I+VSm1uKzxg68p2x9+iGnHfGFNVPdM/7Vyat74Sm+lFF07IrI7ne7LKS9rHQ2Zb+0xQkI4otcXXJLKdYUuQc0xnvk61U="

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-`openzipkin/java` is a minimal Docker image based on [azul/zulu-openjdk-alpine](https://hub.docker.com/r/azul/zulu-openjdk-alpine).
+`ghcr.io/openzipkin/java` is a minimal Docker image based on [azul/zulu-openjdk-alpine](https://hub.docker.com/r/azul/zulu-openjdk-alpine).
 
-On Dockerhub: [openzipkin/java](https://hub.docker.com/r/openzipkin/java/) there will be two tags
+On GitHub Container Registry: [ghcr.io/openzipkin/java](https://github.com/orgs/openzipkin/packages/container/package/java) there will be two tags
 per version. The one ending in `-jre` is a minimal build including modules Zipkin related images
 need. The unqualified is a JDK that also includes Maven.
 

--- a/release.sh
+++ b/release.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh -x
 # Takes a minimal but full JDK image from azul/zulu-openjdk-debian
 # Removes the JDK and keeps the full JRE
 # Then squashes to minimize the image size
 # The resulting images are expected to change rarely, if ever
 
-set -euo pipefail
+set -eu
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 zulu_tag"
@@ -14,8 +14,8 @@ fi
 
 ZULU_TAG="$1"
 
-docker build --build-arg zulu_tag=${ZULU_TAG} -t "openzipkin/java:${ZULU_TAG}" --target jdk .
-docker build --build-arg zulu_tag=${ZULU_TAG} -t "openzipkin/java:${ZULU_TAG}-jre" --target jre .
+docker build --build-arg zulu_tag=${ZULU_TAG} -t "ghcr.io/openzipkin/java:${ZULU_TAG}" --target jdk .
+docker build --build-arg zulu_tag=${ZULU_TAG} -t "ghcr.io/openzipkin/java:${ZULU_TAG}-jre" --target jre .
 
-docker push "openzipkin/java:${ZULU_TAG}"
-docker push "openzipkin/java:${ZULU_TAG}-jre"
+docker push "ghcr.io/openzipkin/java:${ZULU_TAG}"
+docker push "ghcr.io/openzipkin/java:${ZULU_TAG}-jre"


### PR DESCRIPTION
This publishes our images exclusively to GitHub (ghcr) in order to
prevent build outages due to Docker Hub pull limits going into place
on Nov 1 (notably 200 pulls/6hrs). This also prevents our images from
being purged if they had inactivity in six months.

Notably, this requires changing the image name like the following:

```diff
-    JRE_IMAGE=openzipkin/java:15.0.1-15.28.13-jre
+    JRE_IMAGE=ghcr.io/openzipkin/java:15.0.1-15.28.13-jre
```

The images can be viewed here: https://github.com/orgs/openzipkin/packages/container/package/java