### PR TITLE
Refactors to Multi-Arch images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,24 @@ language: bash
 sudo: required
 
 services:
-      - docker
-
-# our specific build below:
+  - docker
 
 before_script:
-  # Log in to Docker Hub for releasing the image
-  - echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
+  # Ensure buildx is available and can build multi-architecture
+  - |
+    export DOCKER_CLI_EXPERIMENTAL=enabled
+    echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+    sudo service docker restart
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    docker buildx create --name builder --use
+  - |
+    # Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
+    # controlled by branch (typically only master). Check to see if a well-known env is available
+    # before attempting to log in.
+    if [[ -n "$GH_USER" ]]; then
+      # Log in to Docker Hub for releasing the image
+      echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
+    fi
 
 script: ./release.sh $TRAVIS_TAG
 
@@ -27,9 +38,11 @@ notifications:
     on_success: change
     on_failure: always
 
-env:
-  global:
-    # Ex. travis encrypt GH_USER=your_github_account
-    - secure: "BWJH4sEQMREo0pEiKc911uNDEFUS9/8S6qXbfouECLGkganh/8XfNR2tOTAna/paUzE/HIq5kb8ayDPj0hWrZ8onAPB5eN8n5/xF/c8iIjYyNEudmKmJdpm0gNkvnxVBVoaNUQPR/sRYMf5vLhwff24buwNARkTn2jxJdVJJktQU12432UjaWR0y1vekgUfiZOlbVwxPvtImPIu0jQipPikG6RgcvFwd5kqK3LVIw1Kox9/44EpwFZIeiwW/f/jxV6bTbnwlps6k44JgOVbygZRwqwmh+OpB8dbdw++agUkd3NcuEDyv4LE9UG9UknYAuAxt++Jns2QjXMt2oMG3+aZiJjbmLB7imP7GDfrDNzDiOYxUIwFsAXC6VXD3NaPt974KxEL3aZLlQAPztC9Wg60fC3SBWoXpYbYsw22qd72bK4Bk8Lms1y4AvZcRwguCnati1FpO0voKS+NnexwDQjJFgRy0NAeRiAHSmO05NB4aqKUIFKLyupqUNt2zECHqVElbZ7tCPv++kxNEgYzPDekcCglk9DFOnbbyRLTm3puI8dpJNhnVEhfkbMnXmU7nhusX1zCSqHaWz8l4spRPtgDgBcYDrVnfwMc3STL3IQe1CAqbf11+28AtfExeR/jEncfIEWTqW2wya/Q1eLl267vq6Ao1c0K9CQRyvp0URf0="
-    # Ex. travis encrypt GH_TOKEN=XXX-https://github.com/settings/tokens-XXX --add
-    - secure: "Zq/LtJSN5O5wxw5mSoadJTWXi4nNaw2irmydq6l/IWCFeOHBlibW7KFFd1ImiY/4v5WDboynKHagOd0zayo7V8woI2d74t0rksaOh7QqZJ4gAxi2oCWLeSHFvZWRZYu2RxopqIpN0UPrJSThSO+R3zZpvK9Dz1VWoOniXvxa7iYfHtgzXObqCGCMEhvRKZNfM+2eG3OXlIG7mnj6hRIjD/lfJiCOZBvekl+zTyg5p/Z1wQCFLFGC5NAYYPgZll+Jgt7LLzlUhx1AOcWAsonxcLL40v+FvslZMVRvDCRZBxedI/jaBDtIJwTsE87B5h0F7M3Teo0oqiImn6mWejMcDPVhwY1m/VwBaAmpip7nx+9EXDZtNn5jb4QiIkT7MxUxpLHbop3WhIa8rn0ybNAlKY2LF2v9Z932H92fbEvOfVhZuDACZ9DGIVXkv/XRIXiNvvYNEZyJ0Tc4U7NG1LFw/BxTPY1HnmOf1uuA2Alboj5A9LOvXHkP3ej2Tqx1lQdDTdqHCeeADwcidekLYhi0caiNn1mE9o44CkSnAJKZMrkL4gWTAMjYyC2j30puI8nhxqlYITwoyZWDxA+I+VSm1uKzxg68p2x9+iGnHfGFNVPdM/7Vyat74Sm+lFF07IrI7ne7LKS9rHQ2Zb+0xQkI4otcXXJLKdYUuQc0xnvk61U="
+# When Travis, add to https://travis-ci.org/github/openzipkin/${REPO}/settings
+#
+# GH_TOKEN=XXX-https://github.com/settings/tokens-XXX
+#   - makes release commits and tags, also writes to GHCR if Docker
+#   - needs repo:status, public_repo and if Docker write:packages, delete:packages
+#   - referenced in .settings.xml
+#   - store like this: echo "https://$GH_TOKEN:@github.com" > .git/credentials
+# GH_USER=user_that_created_GH_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ services:
 before_script:
   # Ensure buildx is available and can build multi-architecture
   - |
+    # Enable experimental features as buildx is still experimental
     export DOCKER_CLI_EXPERIMENTAL=enabled
     echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
     sudo service docker restart
+    # Enable execution of different multi-architecture containers by QEMU and binfmt_misc
+    # See https://github.com/multiarch/qemu-user-static
     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
     docker buildx create --name builder --use
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
-# update docker and enable squash similar to https://github.com/Dalee/build.docker/blob/master/.travis.yml
+# Run `travis lint` when changing this file to avoid breaking the build.
+
+# We need a full VM so that testcontainers can use Docker
+# See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
+arch: amd64           # arm64 is LXD containers which we can't use because we run Docker tests
+os: linux             # required for arch different than amd64
+dist: focal           # newest available distribution
+
 language: bash
-sudo: required
 
 services:
   - docker
 
+env:
+  global:
+    # Enable experimental features as buildx is still experimental
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+
 before_script:
   # Ensure buildx is available and can build multi-architecture
   - |
-    # Enable experimental features as buildx is still experimental
-    export DOCKER_CLI_EXPERIMENTAL=enabled
     echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
     sudo service docker restart
     # Enable execution of different multi-architecture containers by QEMU and binfmt_misc

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,20 @@ language: bash
 services:
   - docker
 
-env:
-  global:
-    # Enable experimental features as buildx is still experimental
-    - DOCKER_CLI_EXPERIMENTAL=enabled
-
-before_script:
-  # Ensure buildx is available and can build multi-architecture
+before_install:
+  # Ensure Docker buildx is available and can build multi-architecture
   - |
-    echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
-    sudo service docker restart
+    # Enable experimental features on the server (multi-arch)
+    echo '{"experimental":"enabled"}' > sudo tee /etc/docker/daemon.json
+    # Enable experimental client features (eg docker buildx)
+    mkdir -p $HOME/.docker && echo '{"experimental":"enabled"}' > $HOME/.docker/config.json
+  - |
+    # Add buildx plugin
+    BUILDX_VERSION=0.4.2
+    BUILDX_URL=https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TRAVIS_CPU_ARCH}
+    mkdir -p $HOME/.docker/cli-plugins
+    ( cd $HOME/.docker/cli-plugins && wget -qO- $BUILDX_URL > docker-buildx && chmod 755 docker-buildx)
+  - |
     # Enable execution of different multi-architecture containers by QEMU and binfmt_misc
     # See https://github.com/multiarch/qemu-user-static
     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,38 @@
 # You can choose to lint this via the following command:
 # docker run --rm -i hadolint/hadolint < Dockerfile
 
-# To allow local builds, we default this to 15. Releases should set this to Zulu's most-specific
-# Java 15 image tag https://hub.docker.com/r/azul/zulu-openjdk-alpine/tags?page=1&name=15
-ARG zulu_tag=15
+# Update, but use a stable version so that there's less layer drift during multi-day releases
+ARG alpine_version=3.12.1
+FROM alpine:$alpine_version as openJDK
 
-FROM azul/zulu-openjdk-alpine:$zulu_tag as zuluJDK
+# OpenJDK Package version from here https://pkgs.alpinelinux.org/packages?name=openjdk15
+ARG java_version
+ENV JAVA_VERSION=$java_version
+
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+    echo http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    PACKAGE=openjdk$(echo ${JAVA_VERSION}| cut -f1 -d.) && \
+    apk --no-cache add ${PACKAGE}=${JAVA_VERSION} && \
+    java -version java_version
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm/
 
 WORKDIR /java
+
 # CD into the directory in order to copy paths without symlinks
 RUN (cd ${JAVA_HOME} && cp -rp * /java/) && \
     # Remove any symlinks as these won't resolve later
     find . -type l -exec rm -f {} \;
 
-FROM alpine:3.12 as base
+FROM alpine:$alpine_version as base
 
-LABEL MAINTAINER OpenZipkin "http://zipkin.io/"
+LABEL maintainer="OpenZipkin https://zipkin.io/"
 
 # Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV JAVA_HOME=/java
 
 # Java relies on /etc/nsswitch.conf. Put host files first or InetAddress.getLocalHost
 # will throw UnknownHostException as the local hostname isn't in DNS.
@@ -29,14 +43,13 @@ RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswit
 # Allow boringssl for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
 RUN apk add --no-cache libc6-compat
 
-ENV JAVA_HOME=/java
 WORKDIR ${JAVA_HOME}
 
 ENTRYPOINT ["/usr/bin/java", "-jar"]
 
 FROM base as jdk
 
-COPY --from=zuluJDK /java/ .
+COPY --from=openJDK /java/ .
 RUN ln -s ${PWD}/bin/java /usr/bin/java && \
     ln -s ${PWD}/bin/jar /usr/bin/jar
 
@@ -48,15 +61,19 @@ RUN apk add --no-cache binutils tar && \
     APACHE_MIRROR=$(wget -qO- https://www.apache.org/dyn/closer.cgi\?as_json\=1 | sed -n '/preferred/s/.*"\(.*\)"/\1/gp') && \
     MAVEN_DIST_URL=$APACHE_MIRROR/maven/maven-3/$maven_version/binaries/apache-maven-$maven_version-bin.tar.gz && \
     mkdir maven && wget -qO- $MAVEN_DIST_URL | tar xz --strip=1 -C maven && \
-    ln -s ${PWD}/maven/bin/mvn /usr/bin/mvn
+    ln -s ${PWD}/maven/bin/mvn /usr/bin/mvn && \
+    mvn -version
 
 # Use a temporary target to build a JRE using the JDK we just built
 FROM jdk as install
 
 WORKDIR /install
 
+RUN JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2| cut -f1 -d.) && \
+# Opt out of --strip-debug when openjdk15+arm64 per https://github.com/openzipkin/docker-java/issues/34
+if [[ "${JAVA_VERSION}" = "15" && "$(uname -m)" = "aarch64" ]]; then STRIP=""; else STRIP="--strip-debug"; fi && \
 # Included modules cherry-picked from https://docs.oracle.com/en/java/javase/15/docs/api/
-RUN ${JAVA_HOME}/bin/jlink --no-header-files --no-man-pages --compress=0 --strip-debug --add-modules \
+${JAVA_HOME}/bin/jlink --vm=server --no-header-files --no-man-pages --compress=0 ${STRIP} --add-modules \
 java.base,java.logging,\
 # java.desktop includes java.beans which is used by Spring
 java.desktop,\

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,11 @@ ENV JAVA_HOME=/java
 # will throw UnknownHostException as the local hostname isn't in DNS.
 RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 
-# Allow boringssl for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
-RUN apk add --no-cache libc6-compat
-
 WORKDIR ${JAVA_HOME}
+
+# Allow boringssl for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
+RUN apk add --no-cache java-cacerts libc6-compat && \
+    mkdir -p lib/security/ && ln -s /etc/ssl/certs/java/cacerts ${PWD}/lib/security/cacerts
 
 ENTRYPOINT ["/usr/bin/java", "-jar"]
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,30 @@
-`ghcr.io/openzipkin/java` is a minimal Docker image based on [azul/zulu-openjdk-alpine](https://hub.docker.com/r/azul/zulu-openjdk-alpine).
+`ghcr.io/openzipkin/java` is a minimal Docker image based on the OpenJDK [Alpine Linux](https://hub.docker.com/_/alpine) package.
 
 On GitHub Container Registry: [ghcr.io/openzipkin/java](https://github.com/orgs/openzipkin/packages/container/package/java) there will be two tags
 per version. The one ending in `-jre` is a minimal build including modules Zipkin related images
 need. The unqualified is a JDK that also includes Maven.
 
 ## Release process
-The Docker build is driven by `--build-arg zulu_tag`. The value of this must be Zulu's most-specific
-Java 15 tag, ex `15.0.0-15.27.17`.
- * You can look here https://hub.docker.com/r/azul/zulu-openjdk-alpine/tags?page=1&name=15
+The Docker build is driven by `--build-arg java_version`. The value of this must be Alpine's
+most specific Java 15 version, ex `15.0.1_p9-r0`.
+ * You can look here https://pkgs.alpinelinux.org/packages?name=openjdk15
 
-Build the `Dockerfile` and verify the image you built matches that tag.
-Ex. `docker build -t openzipkin/java:test-jre --build-arg zulu_tag=15.0.0-15.27.17 .`
+Build the `Dockerfile` and verify the image you built matches that version.
 
-Next, verify the built image matches that `zulu_tag`.
+Ex.
+```bash
+export DOCKER_CLI_EXPERIMENTAL=enabled
+docker buildx create --name builder --use
+docker buildx build --build-arg java_version=15.0.1_p9-r0 --tag openzipkin/java:test-jre --platform=linux/amd64 --target jre --load .
+```
+
+Note: If you want to try another arch, like arm64, make sure you setup qemu first!
+```bash
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx build --build-arg java_version=15.0.1_p9-r0 --tag openzipkin/java:test-jre --platform=linux/arm64 --target jre --load .
+```
+
+Next, verify the built image matches that `java_version`.
 
 For example, given the following output from `docker run --rm openzipkin/java:test-jre -version`...
 ```
@@ -20,11 +32,7 @@ openjdk version "15" 2020-09-15
 OpenJDK Runtime Environment Zulu15.27+17-CA (build 15+36)
 OpenJDK 64-Bit Server VM Zulu15.27+17-CA (build 15+36, mixed mode)
 ```
-The `zulu_tag` arg should be `15.0.0-15.27.17`
+The `java_version` arg should be `15.0.1_p9-r0`
 
-To release the image, push a tag named the same as the `zulu_tag` you built (ex `15.0.0-15.27.17`).
+To release the image, push a tag named the same as the `java_version` you built (ex `15.0.1_p9-r0`).
 This will trigger a [Travis CI](https://travis-ci.org/openzipkin/docker-java) job to push the image.
-
-Note: The upstream Zulu repository has a monthly release cadence. Maintainers should [watch the repo](https://github.com/zulu-openjdk/zulu-openjdk/watchers),
-in case a pull request corresponds to a release. Since not all releases correspond to pull requests,
-another way is to just check again at each month end.

--- a/release.sh
+++ b/release.sh
@@ -13,6 +13,8 @@ ALPINE_VERSION=3.12.1
 JAVA_VERSION="$1"
 PLATFORMS="linux/amd64,linux/arm64"
 
+# buildx is experimental
+export DOCKER_CLI_EXPERIMENTAL=enabled
 BUILDX="docker buildx build --progress plain \
 --build-arg alpine_version=${ALPINE_VERSION} --label alpine-version=${ALPINE_VERSION} \
 --build-arg java_version=${JAVA_VERSION} --label java-version=${JAVA_VERSION}"

--- a/release.sh
+++ b/release.sh
@@ -1,21 +1,36 @@
 #!/bin/sh -x
-# Takes a minimal but full JDK image from azul/zulu-openjdk-debian
-# Removes the JDK and keeps the full JRE
-# Then squashes to minimize the image size
-# The resulting images are expected to change rarely, if ever
 
+# Makes two images based on Alpine Linux. One for OpenJDK and another for a stripped JRE
 set -eu
 
-if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 zulu_tag"
-    echo "  version: the version output from building zulu-openjdk-alpine "
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 java_version"
+    echo "  version from https://pkgs.alpinelinux.org/packages?name=openjdk15: Ex. 15.0.1_p9-r0"
     exit 1
 fi
 
-ZULU_TAG="$1"
+ALPINE_VERSION=3.12.1
+JAVA_VERSION="$1"
+PLATFORMS="linux/amd64,linux/arm64"
 
-docker build --build-arg zulu_tag=${ZULU_TAG} -t "ghcr.io/openzipkin/java:${ZULU_TAG}" --target jdk .
-docker build --build-arg zulu_tag=${ZULU_TAG} -t "ghcr.io/openzipkin/java:${ZULU_TAG}-jre" --target jre .
+BUILDX="docker buildx build --progress plain \
+--build-arg alpine_version=${ALPINE_VERSION} --label alpine-version=${ALPINE_VERSION} \
+--build-arg java_version=${JAVA_VERSION} --label java-version=${JAVA_VERSION}"
 
-docker push "ghcr.io/openzipkin/java:${ZULU_TAG}"
-docker push "ghcr.io/openzipkin/java:${ZULU_TAG}-jre"
+# We need to build separately per arch to test to use -load https://github.com/docker/buildx/issues/59
+# Testing multiple archs likely requires qemu: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+for platform in $(echo $PLATFORMS|tr -s ',' ' '); do
+  for target in jdk jre; do
+    tag=openzipkin/java:test-${target}
+    ${BUILDX} --target ${target} --tag ${tag} --platform=${platform} --load .
+    docker run --rm ${tag} -version
+  done
+done
+
+# If we got here, we assume the images can be trusted. Go ahead and push them
+for target in jdk jre; do
+  tag=ghcr.io/openzipkin/java:${JAVA_VERSION}
+  if [ "$target" = "jre" ]; then tag=${tag}-jre; fi
+  echo Pushing image ${tag}
+  ${BUILDX} --target ${target} --tag ${tag} --platform=${PLATFORMS} --push .
+done


### PR DESCRIPTION
This switches out Zulu for OpenJDK as the former does not publish
multi-arch images. This uses the more complex buildx environment to
produce both amd64 and arm64 images.

See openzipkin/zipkin#3141