### PR TITLE
Refactors travis setup and fixes JAVA_HOME

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# We don't use anything in the current directory
+**

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,33 +11,15 @@ language: bash
 services:
   - docker
 
+# Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
+# controlled by branch (typically only master). Check to see if a well-known env is available
+# before attempting to log in.
 before_install:
-  # Ensure Docker buildx is available and can build multi-architecture
   - |
-    # Enable experimental features on the server (multi-arch)
-    echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
-    sudo service docker restart
-    # Enable experimental client features (eg docker buildx)
-    mkdir -p $HOME/.docker && echo '{"experimental":"enabled"}' > $HOME/.docker/config.json
-  - |
-    # Add buildx plugin
-    BUILDX_VERSION=0.4.2
-    BUILDX_URL=https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TRAVIS_CPU_ARCH}
-    mkdir -p $HOME/.docker/cli-plugins
-    ( cd $HOME/.docker/cli-plugins && wget -qO- $BUILDX_URL > docker-buildx && chmod 755 docker-buildx)
-    docker version
-  - |
-    # Enable execution of different multi-architecture containers by QEMU and binfmt_misc
-    # See https://github.com/multiarch/qemu-user-static
-    if [ "$(uname -m)" = "x86_64" ]; then
-      docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    fi
-    docker buildx create --name builder --use
-  - |
-    # Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
-    # controlled by branch (typically only master). Check to see if a well-known env is available
-    # before attempting to log in.
     if [[ -n "$GH_USER" ]]; then
+      # re-use this condition to control if we prepare Docker for multi-arch
+      build-bin/setup_multiarch_docker
+
       # Log in to Docker Hub for releasing the image
       echo "$GH_TOKEN"| docker login ghcr.io -u "$GH_USER" --password-stdin
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,19 @@ FROM alpine:$alpine_version as base
 
 LABEL maintainer="OpenZipkin https://zipkin.io/"
 
+# OpenJDK Package version from here https://pkgs.alpinelinux.org/packages?name=openjdk15
+ARG java_version
+ENV JAVA_VERSION=$java_version
+ARG java_major_version=15
+ENV JAVA_MAJOR_VERSION=$java_major_version
+
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-ENV JAVA_HOME=/usr/lib/jvm/default-jvm/
+ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_MAJOR_VERSION}-openjdk
+# Prefix Alpine Linux default path with ${JAVA_HOME}/bin
+ENV PATH=${JAVA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Java relies on /etc/nsswitch.conf. Put host files first or InetAddress.getLocalHost
 # will throw UnknownHostException as the local hostname isn't in DNS.
@@ -25,35 +33,28 @@ RUN for repository in main testing community; do \
       grep -qF -- $repository_url /etc/apk/repositories || echo $repository_url >> /etc/apk/repositories; \
     done
 
-# Allow boringssl for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
-RUN apk add --no-cache java-cacerts libc6-compat && \
-    mkdir -p lib/security/ && ln -s /etc/ssl/certs/java/cacerts ${PWD}/lib/security/cacerts
+WORKDIR /java
 
-ENTRYPOINT ["/usr/bin/java", "-jar"]
+ENTRYPOINT ["java", "-jar"]
 
 FROM base as jdk
 
-# OpenJDK Package version from here https://pkgs.alpinelinux.org/packages?name=openjdk15
-ARG java_version
-ENV JAVA_VERSION=$java_version
+# Install OS packages that support most software we build
+# * openjdk15-jdk: smaller than openjdk15, which includes docs and demos
+# * openjdk15-jmods: needed for module support
+# * binutils: needed for some node modules and jlink --strip-debug
+# * tar: BusyBux built-in tar doesn't support --strip=1
+# * libc6-compat: BoringSSL for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
+RUN PACKAGE=openjdk${JAVA_MAJOR_VERSION} && \
+    apk --no-cache add ${PACKAGE}-jmods=~${JAVA_VERSION} ${PACKAGE}-jdk=~${JAVA_VERSION} binutils tar libc6-compat && \
+    java -version && jar --version && jlink --version
 
-RUN PACKAGE=openjdk$(echo ${JAVA_VERSION}| cut -f1 -d.) && \
-    # use the openjdk15-jmods package, not openjdk15, to avoid clutter
-    apk --no-cache add ${PACKAGE}-jmods=~${JAVA_VERSION} ${PACKAGE}-jdk=~${JAVA_VERSION} && \
-    java -version
-
-WORKDIR ${JAVA_HOME}
-
-# * binutils is needed for some node modules and jlink --strip-debug
-# * BusyBux built-in tar doesn't support --strip=1
-# * Maven doesn't need an installer
+# Add Maven and invoke help:evaluate to verify the install as this is used in other release scripts
 ARG maven_version=3.6.3
-RUN apk add --no-cache binutils tar && \
-    APACHE_MIRROR=$(wget -qO- https://www.apache.org/dyn/closer.cgi\?as_json\=1 | sed -n '/preferred/s/.*"\(.*\)"/\1/gp') && \
+RUN APACHE_MIRROR=$(wget -qO- https://www.apache.org/dyn/closer.cgi\?as_json\=1 | sed -n '/preferred/s/.*"\(.*\)"/\1/gp') && \
     MAVEN_DIST_URL=$APACHE_MIRROR/maven/maven-3/$maven_version/binaries/apache-maven-$maven_version-bin.tar.gz && \
     mkdir maven && wget -qO- $MAVEN_DIST_URL | tar xz --strip=1 -C maven && \
     ln -s ${PWD}/maven/bin/mvn /usr/bin/mvn && \
-    # use help:evalate to verify the install as this is used in other release scripts (and will seed some plugins)
     mvn help:evaluate -Dexpression=maven.version -q -DforceStdout
 
 # Use a temporary target to build a JRE using the JDK we just built
@@ -61,12 +62,11 @@ FROM jdk as install
 
 WORKDIR /install
 
-RUN JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2| cut -f1 -d.) && \
 # Opt out of --strip-debug when openjdk15+arm64 per https://github.com/openzipkin/docker-java/issues/34
 # This is because we cannot set the following in jlink -Djdk.lang.Process.launchMechanism=vfork
-if [[ "${JAVA_VERSION}" = "15" && "$(uname -m)" = "aarch64" ]]; then STRIP=""; else STRIP="--strip-debug"; fi && \
+RUN if [[ "${JAVA_MAJOR_VERSION}" = "15" && "$(uname -m)" = "aarch64" ]]; then STRIP=""; else STRIP="--strip-debug"; fi && \
 # Included modules cherry-picked from https://docs.oracle.com/en/java/javase/15/docs/api/
-${JAVA_HOME}/bin/jlink --vm=server --no-header-files --no-man-pages --compress=0 ${STRIP} --add-modules \
+jlink --vm=server --no-header-files --no-man-pages --compress=0 ${STRIP} --add-modules \
 java.base,java.logging,\
 # java.desktop includes java.beans which is used by Spring
 java.desktop,\
@@ -94,7 +94,10 @@ jdk.localedata --include-locales en,th\
 # Our JRE image is minimal: Only Alpine, libc6-compat and a stripped down JRE
 FROM base as jre
 
-WORKDIR ${JAVA_HOME}
-COPY --from=install /install/jre .
+COPY --from=install /install/jre/ ${JAVA_HOME}/
 
-RUN ln -s ${JAVA_HOME}/bin/java /usr/bin/java
+# Finalize JRE install:
+# * java-cacerts: ensures the certificates match what the JDK image contains
+# * libc6-compat: BoringSSL for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
+RUN apk add --no-cache java-cacerts libc6-compat && \
+    java -version

--- a/README.md
+++ b/README.md
@@ -13,15 +13,7 @@ Build the `Dockerfile` and verify the image you built matches that version.
 
 Ex.
 ```bash
-export DOCKER_CLI_EXPERIMENTAL=enabled
-docker buildx create --name builder --use
-docker buildx build --build-arg java_version=15.0.1_p9 --tag openzipkin/java:test-jre --platform=linux/amd64 --target jre --load .
-```
-
-Note: If you want to try another arch, like arm64, make sure you setup qemu first!
-```bash
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-docker buildx build --build-arg java_version=15.0.1_p9 --tag openzipkin/java:test-jre --platform=linux/arm64 --target jre --load .
+docker build --build-arg java_version=15.0.1_p9 --tag openzipkin/java:test-jre --target jre .
 ```
 
 Next, verify the built image matches that `java_version`.
@@ -36,3 +28,14 @@ The `java_version` arg should be `15.0.1_p9`
 
 To release the image, push a tag named the same as the `java_version` you built (ex `15.0.1_p9`).
 This will trigger a [Travis CI](https://travis-ci.org/openzipkin/docker-java) job to push the image.
+
+### Multi-arch
+The release script deploys a multi-architecture image.
+
+If you want to try another arch, like arm64, make sure you user buildx and setup qemu first!
+```bash
+export DOCKER_CLI_EXPERIMENTAL=enabled
+docker buildx create --name builder --use
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx build --build-arg java_version=15.0.1_p9 --tag openzipkin/java:test-jre --platform=linux/arm64 --target jre --load .
+```

--- a/build-bin/setup_multiarch_docker
+++ b/build-bin/setup_multiarch_docker
@@ -13,7 +13,7 @@
 # the License.
 #
 
-set -uex
+set -ue
 
 # Ensures Docker buildx is available and can build multi-architecture
 #

--- a/build-bin/setup_multiarch_docker
+++ b/build-bin/setup_multiarch_docker
@@ -23,7 +23,7 @@ set -ue
 # Verify we are on an arch that can publish multi-arch images
 ARCH=$(uname -m)
 if [ "$ARCH" != "x86_64" ]; then
-  echo multiarch/qemu-user-static doesn't support arch $ARCH
+  echo "multiarch/qemu-user-static doesn't support arch $ARCH"
   exit 1
 fi
 

--- a/build-bin/setup_multiarch_docker
+++ b/build-bin/setup_multiarch_docker
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Copyright 2015-2020 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+set -uex
+
+# Ensures Docker buildx is available and can build multi-architecture
+#
+# This should only happen when we are publishing multi-arch builds, as otherwise the setup will use
+# Docker Hub pull quota and possibly cause a build outage.
+
+# Verify we are on an arch that can publish multi-arch images
+ARCH=$(uname -m)
+if [ "$ARCH" != "x86_64" ]; then
+  echo multiarch/qemu-user-static doesn't support arch $ARCH
+  exit 1
+fi
+
+# Enable experimental features on the server (multi-arch)
+echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+sudo service docker restart
+# Enable experimental client features (eg docker buildx)
+mkdir -p ${HOME}/.docker && echo '{"experimental":"enabled"}' > ${HOME}/.docker/config.json
+
+# Add buildx plugin
+BUILDX_VERSION=0.4.2
+BUILDX_URL=https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-${TRAVIS_CPU_ARCH}
+mkdir -p $HOME/.docker/cli-plugins
+( cd $HOME/.docker/cli-plugins && wget -qO- $BUILDX_URL > docker-buildx && chmod 755 docker-buildx)
+docker version
+
+# Enable execution of different multi-architecture containers by QEMU and binfmt_misc
+# See https://github.com/multiarch/qemu-user-static
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx create --name builder --use

--- a/release.sh
+++ b/release.sh
@@ -15,6 +15,7 @@ PLATFORMS="linux/amd64,linux/arm64"
 
 BUILDX="docker buildx build --progress plain \
 --build-arg alpine_version=${ALPINE_VERSION} --label alpine-version=${ALPINE_VERSION} \
+--build-arg java_major_version=$(echo "${JAVA_VERSION}"| cut -f1 -d.) \
 --build-arg java_version=${JAVA_VERSION} --label java-version=${JAVA_VERSION}"
 
 # We need to build separately per arch to test to use -load https://github.com/docker/buildx/issues/59


### PR DESCRIPTION
This is more explicit about PATH and JAVA_HOME to avoid subtle problems
in downstream builds. This also is a bit more defensive about using
buildx as it can cost Docker Hub pulls.