### PR TITLE
Adds standard labels and references non-docker hub qemu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ jdk.localedata --include-locales en,th\
 # Our JRE image is minimal: Only Alpine, libc6-compat and a stripped down JRE
 FROM base as jre
 
-LABEL description="Minimal OpenJDK JRE on Alpine Linux"
+LABEL org.opencontainers.image.description="Minimal OpenJDK JRE on Alpine Linux"
 
 COPY --from=install /install/jre/ ${JAVA_HOME}/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@
 ARG alpine_version=3.12.1
 FROM alpine:$alpine_version as base
 
-LABEL maintainer="OpenZipkin https://zipkin.io/"
+ARG maintainer="OpenZipkin https://gitter.im/openzipkin/zipkin"
+LABEL maintainer=$maintainer
+LABEL org.opencontainers.image.authors=$maintainer
+LABEL org.opencontainers.image.description="OpenJDK on Alpine Linux"
 
 # OpenJDK Package version from here https://pkgs.alpinelinux.org/packages?name=openjdk15
 ARG java_version
@@ -94,6 +97,8 @@ jdk.localedata --include-locales en,th\
 
 # Our JRE image is minimal: Only Alpine, libc6-compat and a stripped down JRE
 FROM base as jre
+
+LABEL description="Minimal OpenJDK JRE on Alpine Linux"
 
 COPY --from=install /install/jre/ ${JAVA_HOME}/
 

--- a/build-bin/setup_multiarch_docker
+++ b/build-bin/setup_multiarch_docker
@@ -42,5 +42,5 @@ docker version
 
 # Enable execution of different multi-architecture containers by QEMU and binfmt_misc
 # See https://github.com/multiarch/qemu-user-static
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker run --rm --privileged ghcr.io/openzipkin/multiarch-qemu-user-static --reset -p yes
 docker buildx create --name builder --use

--- a/release.sh
+++ b/release.sh
@@ -16,7 +16,9 @@ PLATFORMS="linux/amd64,linux/arm64"
 BUILDX="docker buildx build --progress plain \
 --build-arg alpine_version=${ALPINE_VERSION} --label alpine-version=${ALPINE_VERSION} \
 --build-arg java_major_version=$(echo "${JAVA_VERSION}"| cut -f1 -d.) \
---build-arg java_version=${JAVA_VERSION} --label java-version=${JAVA_VERSION}"
+--build-arg java_version=${JAVA_VERSION} --label java-version=${JAVA_VERSION} \
+--label org.opencontainers.image.source=https://github.com/openzipkin/docker-java \
+--label org.opencontainers.image.version=${JAVA_VERSION}"
 
 # We need to build separately per arch to test to use -load https://github.com/docker/buildx/issues/59
 # Testing multiple archs likely requires qemu: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
This moves to standard labels so that GitHub Container Registry can
display a description. It also uses a mirror of qemu-user-static to
avoid consuming Docker Hub quota on builds.