### PR TITLE
WIP: Support docker build for s390x

### DIFF
--- a/build_image
+++ b/build_image
@@ -19,7 +19,7 @@ OP=${3:-load}
 
 DOCKER_TAG=${DOCKER_TAG:-openzipkin/java:test}
 # Platforms to eventually push to the registry
-PLATFORMS="linux/amd64,linux/arm64"
+PLATFORMS="linux/amd64,linux/arm64,linux/s390x"
 
 DOCKER_ARGS="-f ${DOCKERFILE_PATH} --target ${DOCKER_TARGET} --tag ${DOCKER_TAG} \
 --build-arg alpine_version=${ALPINE_VERSION} --label alpine-version=${ALPINE_VERSION} \


### PR DESCRIPTION
As part of the work to make the docker image `openzipkin/zipkin` available for the `s390x` architecture, this is the preliminary work for the PR in `zipkin` (https://github.com/openzipkin/zipkin/pull/3307)