### PR TITLE
WIP s390x arch support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
 arch:  # only test archs not already tested with GH actions
   - arm64
+  - s390x
 os: linux   # required for arch different than amd64
 dist: focal # newest available distribution
 language: bash

--- a/build-bin/docker/docker_arch
+++ b/build-bin/docker/docker_arch
@@ -35,6 +35,9 @@ case ${docker_arch} in
   aarch64* )
     docker_arch=arm64
     ;;
+  s390x* )
+    arch=s390x
+    ;;
   * )
     >&2 echo "Unsupported DOCKER_ARCH: ${docker_arch}"
     exit 1;

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -64,7 +64,7 @@ for repo in ${docker_repos}; do
 done
 
 docker_args=$($(dirname "$0")/docker_args ${version})
-docker_archs=${DOCKER_ARCHS:-amd64 arm64}
+docker_archs=${DOCKER_ARCHS:-amd64 arm64 s390x}
 
 echo "Will build the following architectures: ${docker_archs}"
 


### PR DESCRIPTION
per https://github.com/openzipkin/zipkin/issues/3310

Current status:

Running in native arch, we can build the images. Running via qemu (needed for multi-arch docker push) crashes still, most easily seen via the following:

```bash
DOCKER_BUILDKIT=1 docker build --progress=plain --platform linux/s390x . --build-arg java_version=15.0.1_p9
DOCKER_BUILDKIT=1 docker build --progress=plain --platform linux/s390x . --build-arg java_version=11.0.9_p11 --build-arg java_home=/usr/lib/jvm/java-11-openjdk
```

[jar_version_crash_jdk15.txt](https://github.com/openzipkin/docker-java/files/5648113/jar_version_crash_jdk15.txt)
[java_version_crash_jdk11.txt](https://github.com/openzipkin/docker-java/files/5648114/java_version_crash_jdk11.txt)

I asked for help here though it might not be solvable in aports https://gitlab.alpinelinux.org/alpine/aports/-/issues/12128#note_128541