### PR TITLE
Installs wget as GH action docker builds keep failing on connection reset

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 # https://docs.docker.com/engine/reference/builder/#dockerignore-file
 **
-!install_jdk_and_maven
+!install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ ARG java_version=15.0.1_p9
 ARG maven_version=3.6.3
 LABEL maven-version=$maven_version
 
-COPY --from=code /code/install_jdk_and_maven .
-RUN ./install_jdk_and_maven $java_version $maven_version && rm install_jdk_and_maven
+COPY --from=code /code/install.sh .
+RUN ./install.sh $java_version $maven_version && rm install.sh
 
 # Use a temporary target to build a JRE using the JDK we just built
 FROM jdk as install

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,8 @@
 # * openjdk15-jdk: smaller than openjdk15, which includes docs and demos
 # * openjdk15-jmods: needed for module support
 # * binutils: needed for some node modules and jlink --strip-debug
-# * tar: BusyBux built-in tar doesn't support --strip=1
+# * tar: BusyBox built-in tar doesn't support --strip=1
+# * wget: BusyBox built-in wget doesn't support --tries=3
 
 set -uex
 
@@ -31,21 +32,25 @@ maven_version=${2?maven_version is required. ex 3.6.3}
 java_major_version=$(echo ${java_version}| cut -f1 -d .)
 package=openjdk${java_major_version}
 
-apk --no-cache add ${package}-jmods=~${java_version} ${package}-jdk=~${java_version} binutils tar
+apk --no-cache add \
+${package}-jmods=~${java_version} ${package}-jdk=~${java_version} binutils tar wget
 
 # Typically, only amd64 is tested in CI: Run commands that ensure binaries match current arch.
 if ! java -version || ! jar --version || ! jlink --version; then maybe_log_crash; fi
+
+# Connection resets are frequent in CI
+alias wget="wget --tries=3 -qO-"
 
 mkdir maven
 # Install Maven by downloading it from and Apache mirror. Prime local repository with common plugins
 maven_dist_path=/maven/maven-3/$maven_version/binaries/apache-maven-${maven_version}-bin.tar.gz
 # Sometimes, closer.cgi returns an empty string
-apache_mirror_json=$(wget -qO- https://www.apache.org/dyn/closer.cgi\?as_json\=1 || echo '{"preferred":"https://downloads.apache.org/"}')
+apache_mirror_json=$(wget https://www.apache.org/dyn/closer.cgi\?as_json\=1 || echo '{"preferred":"https://downloads.apache.org/"}')
 apache_mirror=$(echo $apache_mirror_json | sed -n '/preferred/s/.*"\(.*\)".*/\1/gp')
 # Sometimes, there is a bad mirror in the json
 apache_backup_mirror=https://downloads.apache.org/
 # First try the preferred mirror. If that's bad, use the backup mirror
-(wget -qO- ${apache_mirror}${maven_dist_path} || wget -qO- ${apache_backup_mirror}${maven_dist_path}) | tar xz --strip=1 -C maven
+(wget ${apache_mirror}${maven_dist_path} || wget ${apache_backup_mirror}${maven_dist_path}) | tar xz --strip=1 -C maven
 ln -s ${PWD}/maven/bin/mvn /usr/bin/mvn
 
 mvn -q --batch-mode help:evaluate -Dexpression=maven.version -q -DforceStdout || maybe_log_crash


### PR DESCRIPTION
This costs 10m, but only on the JDK image. The cost of constantly failing builds is worse.