### PR TITLE
Bumps Alpine base image to 3.14.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,14 @@
 # docker_parent_image is the base layer of full and jre image
 #
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
-ARG docker_parent_image=ghcr.io/openzipkin/alpine:3.14.2
+ARG docker_parent_image=ghcr.io/openzipkin/alpine:3.14.3
+
+# java_version is hard-coded here to allow the following to work:
+#  * `docker build https://github.com/openzipkin/docker-java.git`
+#
+# When updating, also update the README
+#  * Use current version from https://pkgs.alpinelinux.org/packages?name=openjdk15
+ARG java_version=15.0.5_p3
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -24,7 +31,7 @@ FROM $docker_parent_image as base
 #  * Use current version from https://pkgs.alpinelinux.org/packages?name=openjdk15
 # This is defined in many places because Docker has no "env" script functionality unless you use
 # docker-compose: When updating, update everywhere.
-ARG java_version=15.0.5_p3
+ARG java_version
 ARG java_home=/usr/lib/jvm/java-15-openjdk
 LABEL java-version=$java_version
 LABEL java-home=$java_home
@@ -41,7 +48,7 @@ ENTRYPOINT ["java", "-jar"]
 # The JDK image includes a few build utilities and Maven
 FROM base as jdk
 LABEL org.opencontainers.image.description="OpenJDK on Alpine Linux"
-ARG java_version=15.0.5_p3
+ARG java_version
 ARG maven_version=3.6.3
 LABEL maven-version=$maven_version
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is an internal base layer primarily used in [zipkin](https://github.com/ope
 
 To try the image, run the `java -version` command:
 ```bash
-docker run --rm ghcr.io/openzipkin/java:15.0.4_p5-r0 -version
+docker run --rm ghcr.io/openzipkin/java:15.0.5_p3-r0 -version
 openjdk version "15.0.4" 2021-07-20
 OpenJDK Runtime Environment (build 15.0.4+5-alpine-r0)
 OpenJDK 64-Bit Server VM (build 15.0.4+5-alpine-r0, mixed mode, sharing)
@@ -25,17 +25,17 @@ OpenJDK 64-Bit Server VM (build 15.0.4+5-alpine-r0, mixed mode, sharing)
 Build the `Dockerfile` using the current version without the revision classifier from here:
  * https://pkgs.alpinelinux.org/packages?name=openjdk15
 ```bash
-# Note 15.0.4_p5 not 15.0.4_p5-r0!
-./build-bin/build 15.0.4_p5
+# Note 15.0.5_p3 not 15.0.5_p3-r0!
+./build-bin/build 15.0.5_p3
 ```
 
 Next, verify the built image matches that version:
 ```bash
 docker run --rm openzipkin/java:test -version
-openjdk version "15.0.4" 2021-07-20
-OpenJDK Runtime Environment (build 15.0.4+5-alpine-r0)
-OpenJDK 64-Bit Server VM (build 15.0.4+5-alpine-r0, mixed mode, sharing)
+openjdk version "15.0.5" 2021-07-20
+OpenJDK Runtime Environment (build 15.0.5+3-alpine-r0)
+OpenJDK 64-Bit Server VM (build 15.0.5+3-alpine-r0, mixed mode, sharing)
 ```
 
-To release the image, push a tag matching the arg to `build-bin/build` (ex `15.0.4_p5`).
+To release the image, push a tag matching the arg to `build-bin/build` (ex `15.0.5_p3`).
 This triggers a [GitHub Actions](https://github.com/openzipkin/docker-java/actions) job to push the image.


### PR DESCRIPTION
Use latest Alpine version that includes fixes for several CVEs