### PR TITLE
Bump base Alpine version and Java version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@
 # docker_parent_image is the base layer of full and jre image
 #
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
-ARG docker_parent_image=ghcr.io/openzipkin/alpine:3.14.3
+ARG docker_parent_image=ghcr.io/openzipkin/alpine:3.15.3
 
 # java_version is hard-coded here to allow the following to work:
 #  * `docker build https://github.com/openzipkin/docker-java.git`
 #
 # When updating, also update the README
 #  * Use current version from https://pkgs.alpinelinux.org/packages?name=openjdk15
-ARG java_version=15.0.5_p3
+ARG java_version=15.0.6_p5-r0
 
 # We copy files from the context into a scratch container first to avoid a problem where docker and
 # docker-compose don't share layer hashes https://github.com/docker/compose/issues/883 normally.
@@ -87,7 +87,7 @@ jdk.unsupported,\
 # Elasticsearch 7+ crashes without Thai Segmentation support
 #  Add <900K instead of a different base layer
 jdk.localedata --include-locales en,th\
- --output jre
+--output jre
 
 # Our JRE image is minimal: Only Alpine, libc6-compat and a stripped down JRE
 FROM base as jre

--- a/README.md
+++ b/README.md
@@ -15,27 +15,27 @@ This is an internal base layer primarily used in [zipkin](https://github.com/ope
 
 To try the image, run the `java -version` command:
 ```bash
-docker run --rm ghcr.io/openzipkin/java:15.0.5_p3-r0 -version
-openjdk version "15.0.4" 2021-07-20
-OpenJDK Runtime Environment (build 15.0.4+5-alpine-r0)
-OpenJDK 64-Bit Server VM (build 15.0.4+5-alpine-r0, mixed mode, sharing)
+docker run --rm ghcr.io/openzipkin/java:15.0.6_p5-r0 -version
+openjdk version "15.0.6" 2022-01-18
+OpenJDK Runtime Environment (build 15.0.6+5-alpine-r0)
+OpenJDK 64-Bit Server VM (build 15.0.6+5-alpine-r0, mixed mode)
 ```
 
 ## Release process
 Build the `Dockerfile` using the current version without the revision classifier from here:
  * https://pkgs.alpinelinux.org/packages?name=openjdk15
 ```bash
-# Note 15.0.5_p3 not 15.0.5_p3-r0!
-./build-bin/build 15.0.5_p3
+# Note 15.0.6_p5 not 15.0.6_p5-r0!
+./build-bin/build 15.0.6_p5
 ```
 
 Next, verify the built image matches that version:
 ```bash
 docker run --rm openzipkin/java:test -version
-openjdk version "15.0.5" 2021-07-20
-OpenJDK Runtime Environment (build 15.0.5+3-alpine-r0)
-OpenJDK 64-Bit Server VM (build 15.0.5+3-alpine-r0, mixed mode, sharing)
+openjdk version "15.0.6" 2022-01-18
+OpenJDK Runtime Environment (build 15.0.6+5-alpine-r0)
+OpenJDK 64-Bit Server VM (build 15.0.6+5-alpine-r0, mixed mode, sharing)
 ```
 
-To release the image, push a tag matching the arg to `build-bin/build` (ex `15.0.5_p3`).
+To release the image, push a tag matching the arg to `build-bin/build` (ex `15.0.6_p5`).
 This triggers a [GitHub Actions](https://github.com/openzipkin/docker-java/actions) job to push the image.


### PR DESCRIPTION
Bumps the base Alpine version to resolve some CVEs. Also bumps the minor Java version.