### PR TITLE
Bump the base alpine version to 3.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # docker_parent_image is the base layer of full and jre image
 #
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
-ARG docker_parent_image=ghcr.io/openzipkin/alpine:3.15.4
+ARG docker_parent_image=ghcr.io/openzipkin/alpine:3.16.0
 
 # java_version is hard-coded here to allow the following to work:
 #  * `docker build https://github.com/openzipkin/docker-java.git`


### PR DESCRIPTION
Resolves CVEs from libcrypto and busybox mainly.

@llinder I see there is no new Java version available though, so I guess this should be released as `15.0.7_p4-r1` or something like that?