### PR TITLE
Updates to latest LTS Java 21 and recent maven

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ name: deploy
 # See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
 on:
   push:
-    tags: '[0-9]+.[0-9]+.[0-9]+**'  # Ex. 8.272.10 or 17.0.8_p7
+    tags: '[0-9]+.[0-9]+.[0-9]+**'  # Ex. 8.272.10 or 21.0.1_p12
 
 jobs:
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,6 @@ jobs:
       # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
       # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
       - name: Test LTS JDK
-        run: build-bin/configure_test && build-bin/test 17.0.8_p7
+        run: build-bin/configure_test && build-bin/test 21.0.1_p12
       - name: Test latest JDK
         run: build-bin/configure_test && build-bin/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 arch:  # only test archs not already tested with GH actions
   - arm64
   - s390x
-os: linux   # required for arch different than amd64
+os: linux   # required for arch different from amd64
 dist: focal # newest available distribution
 language: bash
 services: docker
@@ -19,7 +19,7 @@ before_install: |  # Prevent test build of a documentation-only change.
 install: ./build-bin/configure_test
 script:
   # Test LTS JDK
-  - ./build-bin/test 17.0.8_p7
+  - ./build-bin/test 21.0.1_p12
   # Test latest JDK
   - ./build-bin/test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # docker_parent_image is the base layer of full and jre image
 #
 # Use latest version here: https://github.com/orgs/openzipkin/packages/container/package/alpine
-ARG docker_parent_image=ghcr.io/openzipkin/alpine:3.18.2
+ARG docker_parent_image=ghcr.io/openzipkin/alpine:3.18.5
 
 # java_version is hard-coded here to allow the following to work:
 #  * `docker build https://github.com/openzipkin/docker-java.git`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 GitHub Container Registry: [ghcr.io/openzipkin/java](https://github.com/orgs/openzipkin/packages/container/package/java) includes:
  * `master` tag: latest commit
- * `MAJOR.MINOR.PATCH` tag: release corresponding to a [Current OpenJDK Version](https://pkgs.alpinelinux.org/packages?name=openjdk15)
+ * `MAJOR.MINOR.PATCH` tag: release corresponding to a [Current OpenJDK Version](https://pkgs.alpinelinux.org/packages?name=openjdk21)
 
 Tags ending in `-jre` include only a JRE where unqualified tags include the full JDK, Maven, and a
 few build utilities.
@@ -15,27 +15,27 @@ This is an internal base layer primarily used in [zipkin](https://github.com/ope
 
 To try the image, run the `java -version` command:
 ```bash
-docker run --rm ghcr.io/openzipkin/java:17.0.8_p7 -version
-openjdk version "17.0.5" 2022-10-18
-OpenJDK Runtime Environment (build 17.0.5+8-alpine-r2)
-OpenJDK 64-Bit Server VM (build 17.0.5+8-alpine-r2, mixed mode, sharing)
+docker run --rm ghcr.io/openzipkin/java:21.0.1_p12 -version
+openjdk version "21.0.1" 2023-10-17
+OpenJDK Runtime Environment (build 21.0.1+12-alpine-r0)
+OpenJDK 64-Bit Server VM (build 21.0.1+12-alpine-r0, mixed mode, sharing)
 ```
 
 ## Release process
 Build the `Dockerfile` using the current version without the revision classifier from here:
- * https://pkgs.alpinelinux.org/packages?name=openjdk15
+ * https://pkgs.alpinelinux.org/packages?name=openjdk21
 ```bash
-# Note 17.0.8_p7 not 17.0.8_p7-r0!
-./build-bin/build 17.0.8_p7
+# Note 21.0.1_p12 not 21.0.1_p12-r0!
+./build-bin/build 21.0.1_p12
 ```
 
 Next, verify the built image matches that version:
 ```bash
 docker run --rm openzipkin/java:test -version
-openjdk version "17.0.5" 2022-10-18
-OpenJDK Runtime Environment (build 17.0.5+8-alpine-r2)
-OpenJDK 64-Bit Server VM (build 17.0.5+8-alpine-r2, mixed mode, sharing)
+openjdk version "21.0.1" 2023-10-17
+OpenJDK Runtime Environment (build 21.0.1+12-alpine-r0)
+OpenJDK 64-Bit Server VM (build 21.0.1+12-alpine-r0, mixed mode, sharing)
 ```
 
-To release the image, push a tag matching the arg to `build-bin/build` (ex `17.0.8_p7`).
+To release the image, push a tag matching the arg to `build-bin/build` (ex `21.0.1_p12`).
 This triggers a [GitHub Actions](https://github.com/openzipkin/docker-java/actions) job to push the image.

--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -141,7 +141,7 @@ explicitly defined and `on.tags` is a [glob pattern](https://docs.github.com/en/
 ```yaml
 on:
   push:
-    tags: '[0-9]+.[0-9]+.[0-9]+**'  # Ex. 8.272.10 or 17.0.8_p7
+    tags: '[0-9]+.[0-9]+.[0-9]+**'  # Ex. 8.272.10 or 21.0.1_p12
     branches: master
 
 jobs:
@@ -203,7 +203,7 @@ jobs:
         - if [ "${SHOULD_DEPLOY}" != "true" ]; then travis_terminate 0; fi
         - travis_wait ./build-bin/deploy master
     - stage: deploy
-      # Ex. 8.272.10 or 17.0.8_p7
+      # Ex. 8.272.10 or 21.0.1_p12
       if: tag =~ /^[0-9]+\.[0-9]+\.[0-9]+/ AND type = push AND env(GH_TOKEN) IS present
       install: ./build-bin/configure_deploy
       script: ./build-bin/deploy ${TRAVIS_TAG}

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -46,7 +46,7 @@ if [ -n "${DOCKER_TARGET}" ]; then
 fi
 
 # When non-empty, becomes the base layer including tag appropriate for the image being built.
-# Ex. ghcr.io/openzipkin/java:17.0.8_p7-jre
+# Ex. ghcr.io/openzipkin/java:21.0.1_p12-jre
 #
 # This is not required to be a base (FROM scratch) image like ghcr.io/openzipkin/alpine:3.12.3
 # See https://docs.docker.com/glossary/#parent-image
@@ -60,7 +60,7 @@ if [ -n "${ALPINE_VERSION}" ]; then
   docker_args="${docker_args} --build-arg alpine_version=${ALPINE_VERSION}"
 fi
 
-# When non-empty, becomes the build-arg java_version. Ex. "17.0.8_p7"
+# When non-empty, becomes the build-arg java_version. Ex. "21.0.1_p12"
 # Used to align base layers from https://github.com/orgs/openzipkin/packages/container/package/java
 if [ -n "${JAVA_VERSION}" ]; then
   docker_args="${docker_args} --build-arg java_version=${JAVA_VERSION}"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2019-2020 The OpenZipkin Authors
+# Copyright 2019-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -13,8 +13,8 @@
 # the License.
 
 # Install OS packages that support most software we build
-# * openjdk15-jdk: smaller than openjdk15, which includes docs and demos
-# * openjdk15-jmods: needed for module support
+# * openjdk21-jdk: smaller than openjdk21, which includes docs and demos
+# * openjdk21-jmods: needed for module support
 # * binutils: needed for some node modules and jlink --strip-debug
 # * tar: BusyBox built-in tar doesn't support --strip=1
 # * wget: BusyBox built-in wget doesn't support --tries=3
@@ -27,8 +27,8 @@ function maybe_log_crash() {
   (cat $(ls hs_err_pid*.log) 2>&- || true) && exit 1;
 }
 
-java_version=${1?java_version is required. ex 17.0.8_p7}
-maven_version=${2?maven_version is required. ex 3.6.3}
+java_version=${1?java_version is required. ex --strip-debug}
+maven_version=${2?maven_version is required. ex 3.9.6}
 java_major_version=$(echo ${java_version}| cut -f1 -d .)
 package=openjdk${java_major_version}
 
@@ -53,5 +53,5 @@ apache_backup_mirror=https://downloads.apache.org/
 (wget ${apache_mirror}${maven_dist_path} || wget ${apache_backup_mirror}${maven_dist_path}) | tar xz --strip=1 -C maven
 ln -s ${PWD}/maven/bin/mvn /usr/bin/mvn
 
-mvn -q --batch-mode org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=maven.version -q -DforceStdout || maybe_log_crash
-mvn -q --batch-mode org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get -Dmdep.skip
+mvn -q --batch-mode org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=maven.version -q -DforceStdout || maybe_log_crash
+mvn -q --batch-mode org.apache.maven.plugins:maven-dependency-plugin:3.6.1:get -Dmdep.skip


### PR DESCRIPTION
This updates to the latest LTS version of Java 21.

This also updates maven as it has drifted a while, and removes a jlink workaround that seems no longer necessary.

from my mac silicon after running build per README
```bash
$ docker run --rm openzipkin/java:test -version
openjdk version "21.0.1" 2023-10-17
OpenJDK Runtime Environment (build 21.0.1+12-alpine-r0)
OpenJDK 64-Bit Server VM (build 21.0.1+12-alpine-r0, mixed mode, sharing)
$ docker run --rm --entrypoint /bin/sh openzipkin/java:test -c 'mvn -version'
Apache Maven 3.9.6 (bc0240f3c744dd6b6ec2920b3cd08dcc295161ae)
Maven home: /java/maven
Java version: 21.0.1, vendor: Alpine, runtime: /usr/lib/jvm/java-21-openjdk
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.5.0-10-generic", arch: "aarch64", family: "unix"
```

cc @NishikantThorat we can try your ppc64le after this, though there may be other problems in the downstream images (zipkin uses the base to test elasticsearch etc, and also [we may be moving off alpine anyway](https://github.com/openzipkin/zipkin/issues/3605)). In other words, I'm not sure if folks besides you will be able to support it.

Marking draft until https://github.com/openzipkin/docker-alpine/pull/35