### PR TITLE
ci: adds comments around docker configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1  # only needed to get the sha label
-      # We can't cache Docker without using buildx because GH actions restricts /var/lib/docker
-      # That's ok because DOCKER_PARENT_IMAGE is always ghcr.io and local anyway.
+      # Don't attempt to cache Docker. Sensitive information can be stolen
+      # via forks, and login session ends up in ~/.docker. This is ok because
+      # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Deploy
         env:
           # GH_USER=<user that created GH_TOKEN>

--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -1,9 +1,9 @@
 # Test and Deploy scripts
 
 This is a Docker project, which uses standard conventions for test and deploy. What's notable about
-docker-alpine is that the base layers are only pushed to `ghcr.io`, and tests are simply running the
-`cat /etc/alpine-release`. There's a non-standard `build` script referenced in [../README.md] that
-allows easier manual builds of the Dockerfile.
+docker-java is that the base layers are only pushed to `ghcr.io`, and tests are simply running the
+`-version` command. There's a non-standard `build` script referenced in [../README.md] that allows
+easier manual builds of the Dockerfile.
 
 [//]: # (Below here should be standard for all projects)
 

--- a/build-bin/docker/docker_args
+++ b/build-bin/docker/docker_args
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2020 The OpenZipkin Authors
+# Copyright 2015-2023 The OpenZipkin Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -19,5 +19,10 @@ docker_tag=${1?full docker_tag is required. Ex openzipkin/zipkin:test}
 version=${2:-}
 docker_args=$($(dirname "$0")/docker_args ${version})
 
+# We don't need build kit, but Docker 20.10 no longer accepts --platform
+# without it. It is simpler to always enable it vs require maintainers to use
+# alternate OCI tools. See https://github.com/moby/moby/issues/41552
+export DOCKER_BUILDKIT=1
+
 echo "Building image ${docker_tag}"
-DOCKER_BUILDKIT=1 docker build --network=host --pull ${docker_args} --tag ${docker_tag} .
+docker build --network=host --pull ${docker_args} --tag ${docker_tag} .

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -27,6 +27,10 @@ set -ue
 
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}
 version=${2:-master}
+
+# We don't need build kit, but Docker 20.10 no longer accepts --platform
+# without it. It is simpler to always enable it vs require maintainers to use
+# alternate OCI tools. See https://github.com/moby/moby/issues/41552
 export DOCKER_BUILDKIT=1
 
 case ${version} in


### PR DESCRIPTION
notably about why not cache and also copies a missing comment from openzipkin/zipkin-dependencies#200

Also, resurrects an accidental delete of context from the README