### PR TITLE
Adds java.sql.rowset module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,8 @@ java.base,java.logging,\
 java.desktop,\
 # our default server includes SQL
 java.sql,\
+# MariaDB Connector/J 3.x additionally requires rowset
+java.sql.rowset,\
 # instrumentation
 java.instrument,\
 # remote debug

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ OpenJDK 64-Bit Server VM (build 21.0.1+12-alpine-r0, mixed mode, sharing)
 To release the image, push a tag matching the arg to `build-bin/build` (ex `21.0.1_p12`).
 This triggers a [GitHub Actions](https://github.com/openzipkin/docker-java/actions) job to push the image.
 
+## java.lang.ClassNotFoundException
+
+The image ending in `-jre` is stripped to only retain the minimal modules needed by Zipkin. This is
+to make it as small as possible. If the `zipkin` or `zipkin-slim` images fail with a
+`java.lang.ClassNotFoundException`, it may be related to the modules linked in the [Dockerfile][Dockerfile].
+
+If the package begins with `java.`, `sun.` or `com.sun.`, it is likely a JRE module. To verify, use
+`javap` without any other options. If a result is printed, you need to link a corresponding module.
+
+For example, here's the result of `javax.sql.rowset.serial.SerialException`, which is in the module
+`java.sql.rowset`:
+```
+$ javap javax.sql.rowset.serial.SerialException
+Compiled from "SerialException.java"
+public class javax.sql.rowset.serial.SerialException extends java.sql.SQLException {
+  static final long serialVersionUID;
+  public javax.sql.rowset.serial.SerialException();
+  public javax.sql.rowset.serial.SerialException(java.lang.String);
+}
+```
+
 ## CVEs
 
 This builds JDK and JRE images over our [Alpine Linux](https://github.com/openzipkin/docker-alpine)


### PR DESCRIPTION
MariaDB Connector/J 3.x additionally requires rowset, and without it crashes like so:
```
zipkin        | Caused by: java.lang.ClassNotFoundException: javax.sql.rowset.serial.SerialException
zipkin        | 	at java.base/java.net.URLClassLoader.findClass(Unknown Source) ~[?:?]
zipkin        | 	at java.base/java.lang.ClassLoader.loadClass(Unknown Source) ~[?:?]
zipkin        | 	at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:151) ~[zipkin/:?]
zipkin        | 	at java.base/java.lang.ClassLoader.loadClass(Unknown Source) ~[?:?]
```