### PR TITLE
reduces stripped JRE to what zipkin needs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ FROM jdk as install
 WORKDIR /install
 
 # Included modules cherry-picked from https://docs.oracle.com/en/java/javase/21/docs/api/
+#
+# Note: Only include modules needed for the openzipkin/zipkin and
+# openzipkin/zipkin-slim images. It is fine for test images to use a full JRE.
 RUN jlink --vm=server --no-header-files --no-man-pages --compress=0 --strip-debug --add-modules \
 java.base,java.logging,\
 # java.desktop includes java.beans which is used by Spring
@@ -80,17 +83,12 @@ java.instrument,\
 jdk.jdwp.agent,\
 # JVM metrics such as garbage collection
 jdk.management,\
-# Prevents us from needing a different base layer for kafka-zookeeper
-# non-Netty based DNS
-java.naming,jdk.naming.dns,\
-# TLS handehake with servers that use elliptic curve certificates
+# TLS handshake with servers that use elliptic curve certificates
 jdk.crypto.ec,\
 # jdk.unsupported is undocumented but contains Unsafe, which is used by several dependencies to
 # improve performance. Ex. sun.misc.Unsafe and friends
 jdk.unsupported,\
-# Elasticsearch 7+ crashes without Thai Segmentation support
-#  Add <900K instead of a different base layer
-jdk.localedata --include-locales en,th \
+jdk.localedata --include-locales en \
 --output jre
 
 # Our JRE image is minimal: Only Alpine, gcompat and a stripped down JRE


### PR DESCRIPTION
Before, we added extra modules that are only used by our demo images. This turns out a fool's errand as recent Elasticsearch needs even more than before (e.g. kerberos stuff). Instead, we will switch the image to only pick what's required in the zipkin builds. Ancillary images can use the full dist.