### PR TITLE
Remove outdated DOCKER_BUILDKIT workarounds

### DIFF
--- a/build-bin/docker/docker_build
+++ b/build-bin/docker/docker_build
@@ -10,10 +10,5 @@ docker_tag=${1?full docker_tag is required. Ex openzipkin/zipkin:test}
 version=${2:-}
 docker_args=$($(dirname "$0")/docker_args ${version})
 
-# We don't need build kit, but Docker 20.10 no longer accepts --platform
-# without it. It is simpler to always enable it vs require maintainers to use
-# alternate OCI tools. See https://github.com/moby/moby/issues/41552
-export DOCKER_BUILDKIT=1
-
 echo "Building image ${docker_tag}"
 docker build --network=host --pull ${docker_args} --tag ${docker_tag} .

--- a/build-bin/docker/docker_push
+++ b/build-bin/docker/docker_push
@@ -10,19 +10,10 @@
 #
 # Note: In CI, `configure_docker_push` must be called before invoking this.
 #
-# Avoid buildx on push for reasons including:
-#  * Caching is more complex as builder instances must be considered
-#  * Platform builds run in parallel, leading to port conflict failures (ex in cassandra)
-#  * 0.4.2 multi-platform builds have failed due to picking the wrong image for a FROM instruction
 set -ue
 
 docker_image=${1?docker_image is required, notably without a tag. Ex openzipkin/zipkin}
 version=${2:-master}
-
-# We don't need build kit, but Docker 20.10 no longer accepts --platform
-# without it. It is simpler to always enable it vs require maintainers to use
-# alternate OCI tools. See https://github.com/moby/moby/issues/41552
-export DOCKER_BUILDKIT=1
 
 case ${version} in
   master )


### PR DESCRIPTION
## Summary
- Remove `export DOCKER_BUILDKIT=1` from `docker_build` and `docker_push`
- Remove outdated comments about buildx avoidance in `docker_push`

BuildKit is the default since Docker 23. The explicit export and related comments are no longer needed and can interfere with attestation on push.

Same change as https://github.com/openzipkin/zipkin/pull/3823